### PR TITLE
Integrate monitoring-system-ruleserver into SODALITE CI-CD pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,20 +1,91 @@
 pipeline {
     agent { label 'docker-slave' }
+    environment {
+        // CI-CD vars
+        docker_registry_ip = credentials('jenkins-docker-registry-ip')
+       // When triggered from git tag, $BRANCH_NAME is actually GIT's tag_name
+       TAG_SEM_VER_COMPLIANT = """${sh(
+                returnStdout: true,
+                script: './resources/CI-CD/validate_tag.sh SemVar $BRANCH_NAME'
+            )}"""
+
+       TAG_MAJOR_RELEASE = """${sh(
+                returnStdout: true,
+                script: './resources/CI-CD/validate_tag.sh MajRel $BRANCH_NAME'
+            )}"""
+
+       TAG_PRODUCTION = """${sh(
+                returnStdout: true,
+                script: './resources/CI-CD/validate_tag.sh production $BRANCH_NAME'
+            )}"""
+
+       TAG_STAGING = """${sh(
+                returnStdout: true,
+                script: './resources/CI-CD/validate_tag.sh staging $BRANCH_NAME'
+            )}"""
+   }
     stages {
         stage ('Pull repo code from github') {
             steps {
                 checkout scm
             }
         }
-        stage('Build Docker image') {
+        stage('Inspect GIT TAG'){
             steps {
-                sh "git fetch --tags && resources/bin/make_docker.sh build sodaliteh2020/monitoring-system"
+                sh """ #!/bin/bash
+                echo 'TAG: $BRANCH_NAME'
+                echo 'Tag is compliant with SemVar 2.0.0: $TAG_SEM_VER_COMPLIANT'
+                echo 'Tag is Major release: $TAG_MAJOR_RELEASE'
+                echo 'Tag is production: $TAG_PRODUCTION'
+                echo 'Tag is staging: $TAG_STAGING'
+                """
             }
         }
-        stage('Push image to DockerHub') {
+        stage('Build monitoring-system-ruleserver') {
+            when {
+                allOf {
+                    // Triggered on every tag, that is considered for staging or production
+                    expression{tag "*"}
+                    expression{
+                        TAG_STAGING == 'true' || TAG_PRODUCTION == 'true'
+                    }
+                }
+             }
+            steps {
+                sh "cd ruleserver/app/ && ../../resources/CI-CD/make_docker.sh build monitoring-system-ruleserver"
+            }
+        }
+        stage('Push monitoring-system-ruleserver to sodalite-private-registry') {
+            // Push during staging and production
+            when {
+                allOf {
+                    expression{tag "*"}
+                    expression{
+                        TAG_STAGING == 'true' || TAG_PRODUCTION == 'true'
+                    }
+                }
+            }
             steps {
                 withDockerRegistry(credentialsId: 'jenkins-sodalite.docker_token', url: '') {
-                    sh "resources/bin/make_docker.sh push sodaliteh2020/monitoring-system"
+                    sh  """#!/bin/bash
+                        ./resources/CI-CD/make_docker.sh push monitoring-system-ruleserver staging
+                        """
+                }
+            }
+        }
+        stage('Push monitoring-system-ruleserver to DockerHub') {
+            when {
+                allOf {
+                    // Triggered on every tag, that is considered for staging or production
+                    expression{tag "*"}
+                    expression{
+                        TAG_PRODUCTION == 'true'
+                    }
+                }
+             }
+            steps {
+                withDockerRegistry(credentialsId: 'jenkins-sodalite.docker_token', url: '') {
+                    sh "./resources/CI-CD/make_docker.sh push monitoring-system-ruleserver production"
                 }
             }
         }

--- a/resources/CI-CD/make_docker.sh
+++ b/resources/CI-CD/make_docker.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# Build or push an image.
+# Images for staging are pushed to sodalite-private-registry on ${docker_registry_ip}
+# Images with production-ready version are pushed to both sodalite-private-registry and dockerhub: sodaliteh2020 repository
+
+# Images from tagged commits are tagged with git tag
+# Images from non-tagged commits are tagged with <last_git_tag>-<commits_since_tag>-<abbreviated_commit_sha>
+#
+# Usage:
+#   $0 build <image-name> [Dockerfile-filename]
+#   $0 push <image-name> [production|staging]
+# image name is pure name without repository (image-name, not sodaliteh2020/image-name)
+
+build() {
+    set -x
+    docker build --build-arg VERSION="${VERSION}" --build-arg DATE="${DATE}" -t "${IMAGE}":latest -f "${FILE}" .
+    set +x
+}
+
+push() {
+
+    set -x
+    docker tag "${IMAGE}":latest "${TARGET_REGISTRY}/${IMAGE}:${VERSION}"
+    docker tag "${IMAGE}":latest "${TARGET_REGISTRY}/${IMAGE}:latest"
+    docker push "${TARGET_REGISTRY}/${IMAGE}:${VERSION}"
+    docker push "${TARGET_REGISTRY}/${IMAGE}:latest"
+    set +x
+}
+
+
+if [[ $# -gt 3 ]] || [[ $# -lt 2 ]] || \
+   [[ "$1" != "build" && "$1" != "push" ]] || \
+   [[ "$1" = "push" && "$3" != "staging" && "$3" != "production" ]]; then
+
+    echo "Usage: $0 build <image-name> [Dockerfile-filename]"
+    echo "Usage: $0 push <image-name> [production|staging]"
+    exit 1
+fi
+
+git fetch --tags
+
+ACTION=$1
+IMAGE=$2
+if [ "$ACTION" = 'build' ];
+  then
+    FILE=${3:-Dockerfile}
+  else
+    TARGET=${3:-staging}
+fi
+
+if [[ "$ACTION" = 'push' ]]; then
+  if [[ "$TARGET" = 'production' ]]; then
+    TARGET_REGISTRY=sodaliteh2020
+  else
+    TARGET_REGISTRY=${docker_registry_ip:-localhost}
+  fi
+fi
+
+VERSION=$(git describe --tag --always | sed -e"s/^v//")
+DATE=$(date -u +%Y-%m-%dT%H:%M:%S)
+
+# debug section
+echo "make_docker.sh:"
+echo "ACTION: $ACTION"
+echo "IMAGE: $IMAGE"
+echo "FILE: $FILE"
+echo "VERSION: $VERSION"
+echo "DATE: $DATE"
+echo "TARGET: $TARGET"
+echo "TARGET_REGISTRY: $TARGET_REGISTRY"
+
+
+if [ "$ACTION" = "build" ]; then
+    build
+else
+    push
+fi

--- a/resources/CI-CD/validate_tag.sh
+++ b/resources/CI-CD/validate_tag.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# Set of Regular expressions / checks to ensure compliance of git version tags with SODALITE standards
+#
+# <valid prerelease tag> ::= <version core> "-" <pre-release>
+#                          | <version core> "-" <pre-release> "+" <build>
+#                          | <major release>
+#
+# <valid release tag> ::= <version core>
+#                       | <version core> "+" <build>
+#                       | <major release>
+#
+# <major release> ::= "M18Release" | "M24Release" | "M36Release"
+#
+# <version core> ::= <major> "." <minor> "." <patch>
+
+# Usage:
+#   $0 [SemVar|SemVarStage|SemVarProd|MajRel|production|staging] <tag>
+
+FUNC=$1
+VALUE=$2
+
+# Functions
+
+SemVar() {
+  if [[ "$VALUE" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$ ]]; then
+    echo true | tr -d '\n'
+  else
+    echo false | tr -d '\n'
+  fi
+}
+
+SemVarStage() {
+  if [[ "$VALUE" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$ ]]; then
+    echo true | tr -d '\n'
+  else
+    echo false | tr -d '\n'
+  fi
+}
+
+SemVarProd() {
+  if [[ "$VALUE" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$ ]]; then
+    echo true | tr -d '\n'
+  else
+    echo false | tr -d '\n'
+  fi
+}
+
+MajorRelease() {
+  if [[ "$VALUE" == "M18Release" ]] || [[ "$VALUE" == "M24Release" ]] || [[ "$VALUE" == "M36Release" ]]; then
+    echo true | tr -d '\n'
+  else
+    echo false | tr -d '\n'
+  fi
+}
+
+Production() {
+
+  if [[ "$(SemVarProd)" == true ]] || [[ "$(MajorRelease)" == true ]]; then
+    echo true | tr -d '\n'
+  else
+    echo false | tr -d '\n'
+  fi
+
+}
+
+Staging() {
+  if [[ "$(SemVarStage)" == true ]] || [[ "$(MajorRelease)" == true ]]; then
+    echo true | tr -d '\n'
+  else
+    echo false | tr -d '\n'
+  fi
+}
+
+# Help
+
+if [[ $# -gt 2 ]] || [[ $# -lt 2 ]] ||
+  [[ "$1" != "SemVar" && "$1" != "SemVarStage" && "$1" != "SemVarProd" && "$1" != "MajRel" && "$1" != "production" && "$1" != "staging" ]]; then
+
+  echo "Usage: $0 [SemVar|SemVarStage|SemVarProd|MajRel|production|staging] <tag>"
+  exit 1
+fi
+
+# checks compliance with Semantic versioning 2.0.0 (https://semver.org/spec/v2.0.0.html)
+if [[ "$FUNC" == "SemVar" ]]; then
+  SemVar
+  exit
+fi
+
+# checks if tag has pre-release and is compliant with Semantic versioning 2.0.0 (https://semver.org/spec/v2.0.0.html)
+if [[ "$FUNC" == "SemVarStage" ]]; then
+  SemVarStage
+  exit
+fi
+
+# checks if tag does not have pre-release and is compliant with Semantic versioning 2.0.0 (https://semver.org/spec/v2.0.0.html)
+if [[ "$FUNC" == "SemVarProd" ]]; then
+  SemVarProd
+  exit
+fi
+
+# checks if tag in form of major release (M18Release,M24Release,M36Release)
+if [[ "$FUNC" == "MajRel" ]]; then
+  MajorRelease
+  exit
+fi
+
+# checks if tag is ready for production (SemVarProd or MajorRelease)
+if [[ "$FUNC" == "production" ]]; then
+  Production
+  exit
+fi
+
+# checks if tag is ready for staging (SemVarStage or MajorRelease)
+if [[ "$FUNC" == "staging" ]]; then
+  Staging
+  exit
+fi

--- a/ruleserver/app/Dockerfile
+++ b/ruleserver/app/Dockerfile
@@ -1,3 +1,13 @@
+FROM alpine:3.12 as builder
+
+ENV PROMETHEUS_VERSION=2.23.0
+
+# Download promtool from Prometheus site
+RUN apk --update add wget tar \
+    && wget -c https://github.com/prometheus/prometheus/releases/download/v${PROMETHEUS_VERSION}/prometheus-${PROMETHEUS_VERSION}.linux-amd64.tar.gz \
+    && tar -xzf prometheus-${PROMETHEUS_VERSION}.linux-amd64.tar.gz \
+    && mv prometheus-${PROMETHEUS_VERSION}.linux-amd64 prometheus
+
 FROM python:3.8-slim-buster
 
 # LABEL maintainer="fabeirojorge.secondwindow@gmail.com"
@@ -7,8 +17,7 @@ RUN apt-get update -y && \
 
 COPY ./requirements.txt /app/requirements.txt
 
-# If rebuilt, must be downloaded first from Prometheus website
-COPY ./promtool /bin/promtool
+COPY --from=builder prometheus/promtool /bin/promtool
 
 WORKDIR /app
 


### PR DESCRIPTION
## CI-CD integration for monitoring-system-ruleserver
- download prometheus inside build stage of Dockerfile
- build image with jenkins
- push to SODALITE private repo on staging and production tags
- push to dockerhub (`sodaliteh2020/monitoring-system-ruleserver`) on production tags

### Notes:
- In order to trigger building and pushing, Github release must be created
- Tag must comply with [SemVer 2.0.0](https://semver.org/spec/v2.0.0.html)
- Staging-tag must contain [pre-release version](pre-release), while production-tag must not
- Building pipeline must be triggered manually with [SODALITE jenkins](https://jenkins.sodalite.eu/job/Monitoring%20system/view/tags/) 